### PR TITLE
2.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
         "pacote":                 "15.2.0",
         "progress":               "2.0.3",
         "event-stream":           "4.0.1",
-        "stream-wrapper":         "0.1.2",
         "pretty-bytes":           "5.6.0",
         "update-notifier":        "5.1.0",
         "fast-diff":              "1.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name":        "upd",
     "homepage":    "http://github.com/rse/upd",
     "description": "Upgrade NPM Package Dependencies",
-    "version":     "2.9.2",
+    "version":     "2.9.3",
     "license":     "MIT",
     "author": {
         "name":    "Dr. Ralf S. Engelschall",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "email":   "rse@engelschall.com",
         "url":     "http://engelschall.com"
     },
+    "type": "commonjs",
     "keywords": [
         "upgrade", "package", "dependency", "npm", "package.json"
     ],

--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
         "upd":  "./upd.js"
     },
     "devDependencies": {
-        "eslint":                 "8.43.0",
+        "eslint":                 "8.46.0",
         "eslint-config-standard": "17.1.0",
         "eslint-plugin-promise":  "6.1.1",
-        "eslint-plugin-import":   "2.27.5",
+        "eslint-plugin-import":   "2.28.0",
         "eslint-plugin-node":     "11.1.0"
     },
     "dependencies" : {
         "yargs":                  "17.7.2",
-        "semver":                 "7.5.3",
+        "semver":                 "7.5.4",
         "awaity":                 "1.0.0",
         "pacote":                 "15.2.0",
         "progress":               "2.0.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
         "awaity":                 "1.0.0",
         "pacote":                 "15.2.0",
         "progress":               "2.0.3",
-        "event-stream":           "4.0.1",
         "pretty-bytes":           "5.6.0",
         "update-notifier":        "5.1.0",
         "fast-diff":              "1.3.0",


### PR DESCRIPTION
- release version 2.9.3
- removed unused dependency "event-stream"
- removed unused dependency "stream-wrapper" to get rid of error message: " WARN  deprecated object-keys@0.2.0: Please update to the latest object-keys"
- added type: commonjs to package.json
- upgrade dependencies
