### PR TITLE
feat: add --pinLatest flag to resolve "latest" to exact version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Usage
 -----
 
 ```
-$ upd [-h] [-V] [-q] [-n] [-C] [-f <file>] [-g] [-a] [-c <concurrency>] [<pattern> ...]
+$ upd [-h] [-V] [-q] [-n] [-C] [-f <file>] [-g] [-a] [-c <concurrency>] [-P] [<pattern> ...]
 ```
 
 - `-h`, `--help`<br/>
@@ -56,6 +56,8 @@ $ upd [-h] [-V] [-q] [-n] [-C] [-f <file>] [-g] [-a] [-c <concurrency>] [<patter
   Show all packages (instead of just updated ones).
 - `-c <concurrency>`, `--concurrency <concurrency>`<br/>
   Number of concurrent network connections to NPM registry.
+- `-P`, `--pin-latest`<br/>
+  Pin "latest" tag to exact version (e.g., "latest" → "1.0.0").
 - `<pattern>`<br/>
   Positive or negative (if prefixed with `!`) Glob pattern for matching
   names of dependencies to update.

--- a/upd.js
+++ b/upd.js
@@ -54,7 +54,7 @@ import ducky             from "ducky"
     /*  command-line option parsing  */
     const argv = yargs()
         /* eslint @stylistic/indent: off */
-        .usage("Usage: $0 [-h] [-V] [-q] [-n] [-C] [-m <name>] [-f <file>] [-g] [-a] [-c <concurrency>] [<pattern> ...]")
+        .usage("Usage: $0 [-h] [-V] [-q] [-n] [-C] [-m <name>] [-f <file>] [-g] [-a] [-c <concurrency>] [-P] [<pattern> ...]")
         .help("h").alias("h", "help").default("h", false)
             .describe("h", "show usage help")
         .boolean("V").alias("V", "version").default("V", false)
@@ -73,6 +73,8 @@ import ducky             from "ducky"
             .describe("a", "show all packages (instead of just updated ones)")
         .number("c").nargs("c", 1).alias("c", "concurrency").default("c", 8)
             .describe("c", "number of concurrent network connections to NPM registry")
+        .boolean("P").alias("P", "pin-latest").default("P", false)
+            .describe("P", "pin 'latest' tag to exact semver version")
         .version(false)
         .strict()
         .showHelpOnFail(true)
@@ -149,6 +151,10 @@ import ducky             from "ducky"
                 const m = sOld.match(/^\s*(?:[\^~]\s*)?(\d+[^<>=|\s]*)\s*$/)
                 if (m !== null) {
                     vOld = m[1]
+                    state = "check"
+                }
+                else if (argv.pinLatest && /^\s*latest\s*$/i.test(sOld)) {
+                    vOld = sOld.trim()
                     state = "check"
                 }
                 else
@@ -252,16 +258,26 @@ import ducky             from "ducky"
             if (spec.state === "check") {
                 spec.vNew = vNew
                 spec.sNew = vNew
+                let needsUpdate = false
                 if (spec.vOld === spec.vNew)
                     spec.state = "kept"
+                else if (/^latest$/i.test(spec.vOld))
+                    needsUpdate = true
                 else if (semver.gt(spec.vOld, spec.vNew))
                     spec.state = "kept"
-                else {
+                else
+                    needsUpdate = true
+
+                if (needsUpdate) {
                     spec.state = "updated"
                     updates++
 
                     /*  update manifest  */
-                    const re = new RegExp(escRE(spec.vOld), "")
+                    let re
+                    if (/^latest$/i.test(spec.vOld))
+                        re = /latest/i
+                    else
+                        re = new RegExp(escRE(spec.vOld), "")
                     spec.sNew = spec.sOld.replace(re, spec.vNew)
                     if (spec.sNew === spec.sOld)
                         throw new Error(`failed to update module "${name}" version string "${spec.sOld}" ` +

--- a/upd.js
+++ b/upd.js
@@ -146,6 +146,7 @@ import ducky             from "ducky"
             const patterns = noPatterns ? [] : (argv._[0].match(/^!/) ? [ "**" ] : []).concat(argv._)
             const matchesPattern = noPatterns || micromatch([ module ], patterns).length > 0
             let state = matchesPattern ? "todo" : "ignored"
+            let isLatest = false
             if (state === "todo") {
                 /*  extract semantic version number from dependency string  */
                 const m = sOld.match(/^\s*(?:[\^~]\s*)?(\d+[^<>=|\s]*)\s*$/)
@@ -156,13 +157,14 @@ import ducky             from "ducky"
                 else if (argv.pinLatest && /^\s*latest\s*$/i.test(sOld)) {
                     vOld = sOld.trim()
                     state = "check"
+                    isLatest = true
                 }
                 else
                     state = "skipped"
             }
             if (manifest[module] === undefined)
                 manifest[module] = []
-            manifest[module].push({ section, sOld, vOld, sNew: sOld, vNew: vOld, state })
+            manifest[module].push({ section, sOld, vOld, sNew: sOld, vNew: vOld, state, isLatest })
         }
     }
     mixin("optionalDependencies")
@@ -261,7 +263,7 @@ import ducky             from "ducky"
                 let needsUpdate = false
                 if (spec.vOld === spec.vNew)
                     spec.state = "kept"
-                else if (/^latest$/i.test(spec.vOld))
+                else if (spec.isLatest)
                     needsUpdate = true
                 else if (semver.gt(spec.vOld, spec.vNew))
                     spec.state = "kept"
@@ -273,11 +275,7 @@ import ducky             from "ducky"
                     updates++
 
                     /*  update manifest  */
-                    let re
-                    if (/^latest$/i.test(spec.vOld))
-                        re = /latest/i
-                    else
-                        re = new RegExp(escRE(spec.vOld), "")
+                    const re = spec.isLatest ? /latest/i : new RegExp(escRE(spec.vOld), "")
                     spec.sNew = spec.sOld.replace(re, spec.vNew)
                     if (spec.sNew === spec.sOld)
                         throw new Error(`failed to update module "${name}" version string "${spec.sOld}" ` +


### PR DESCRIPTION
Add new command-line option `-P, --pinLatest` that converts "latest" tag dependencies to their actual resolved semver version from the NPM registry.

This addresses GitHub issue #8 where users need to pin "latest" tags to exact versions in package.json for reproducible builds.

Changes:
- Added `-P, --pin-latest` CLI option (default: false)
- Modified version parsing to recognize "latest" when flag is enabled
- Updated manifest replacement logic with case-insensitive regex for "latest"
- Refactored update logic to handle "latest" as special state
- Updated README.md with usage and documentation

Example:
  Before: "semver": "latest" After:  "semver": "7.7.4"

The feature is opt-in and maintains backward compatibility - without the flag, "latest" dependencies continue to be skipped (unchanged behavior).

Fixes: #8

Assisted-by: Kimi K2.5 via Crush <crush@charm.land>